### PR TITLE
Add valid timestamp of the published image

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,6 +183,7 @@ int main(int argc, char** argv) {
                                                              frame).toImageMsg();
 
             std::string frame_id = "cam_" + CAMERA_ID;
+            image->header.stamp = ros::Time::now();
             image->header.frame_id = frame_id;
             // Get current CameraInfo data
             sensor_msgs::CameraInfoPtr ci(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,42 +22,42 @@ using namespace ros;
 
 bool to_publish = false;
 
-void clean_up_gracefully(std::string id = "")
-{
+void clean_up_gracefully(std::string id = "") {
     ros::param::del("~");
     ros::shutdown();
-    if (id.size() != 0){
-        ROS_INFO("[NETCAM_STREAM_%s] Attempting to kill image_proc in 2 sec.", id.c_str());
+    if (id.size() != 0) {
+        ROS_INFO(
+            "[NETCAM_STREAM_%s] Attempting to kill image_proc in 2 sec.",
+            id.c_str());
         ros::Duration(5).sleep(); // Wait before killing the node
         system(("rosnode kill netcam_stream_" + id + "/image_proc_" + id).c_str());
     }
 }
 
 // Replacement SIGINT handler
-void mySigIntHandler(int sig)
-{
+void mySigIntHandler(int sig) {
     ROS_WARN("[NETCAM_STREAM] Shutdown request received. Reason id: %d", sig);
     clean_up_gracefully();
 }
 
 // Replacement "shutdown" XMLRPC callback
-void shutdownCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result)
-{
+void shutdownCallback(XmlRpc::XmlRpcValue& params,
+                      XmlRpc::XmlRpcValue& result) {
     int num_params = 0;
     if (params.getType() == XmlRpc::XmlRpcValue::TypeArray)
-    num_params = params.size();
-    if (num_params > 1)
-    {
+        num_params = params.size();
+    if (num_params > 1) {
         std::string reason = params[1];
-        ROS_WARN("[NETCAM_STREAM] Shutdown request received. Reason: [%s]", reason.c_str());
+        ROS_WARN(
+            "[NETCAM_STREAM] Shutdown request received. Reason: [%s]",
+            reason.c_str());
         clean_up_gracefully();
     }
 
     result = ros::xmlrpc::responseInt(1, "", 0);
 }
 
-void publish_image_callback(const ros::TimerEvent&)
-{
+void publish_image_callback(const ros::TimerEvent&) {
     to_publish = true;
 }
 
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
     ros::NodeHandle node("~");
 
     int id; std::string CAMERA_ID;
-    if (!node.getParam("camera_id", id)){
+    if (!node.getParam("camera_id", id)) {
         ROS_FATAL("[NETCAM_STREAM] Cannot read 'camera_id' from param server.");
         clean_up_gracefully();
         return 0;
@@ -94,7 +94,9 @@ int main(int argc, char** argv) {
     if (!node.getParam("/cam_user", user)) {
         if (!node.getParam("/launch_user", user) || (user == "user")) {
             ROS_FATAL(
-                "[NETCAM_STREAM_%d] Cannot read username from param server (cam_user) or launch file is not changed (launch_user).", id);
+                "[NETCAM_STREAM_%d] Cannot read username from param server "
+                "(cam_user) or launch file is not changed (launch_user).",
+                id);
             clean_up_gracefully(CAMERA_ID);
             return 0;
         }
@@ -103,15 +105,20 @@ int main(int argc, char** argv) {
     if (!node.getParam("/cam_pass", pass)) {
         if (!node.getParam("/launch_pass", pass) || (pass == "pass")) {
             ROS_FATAL(
-                "[NETCAM_STREAM_%d] Cannot read password from param server (cam_pass) or launch file is not changed (launch_pass).", id);
+                "[NETCAM_STREAM_%d] Cannot read password from param server "
+                "(cam_pass) or launch file is not changed (launch_pass).",
+                id);
             clean_up_gracefully(CAMERA_ID);
             return 0;
         }
     }
 
     int frame_rate;
-    if (!node.getParam("/frame_rate", frame_rate)){
-        ROS_WARN("[NETCAM_STREAM_%d] Camera frequency ('frame_rate') cannot be read. Using 30 Hz.", id);
+    if (!node.getParam("/frame_rate", frame_rate)) {
+        ROS_WARN(
+            "[NETCAM_STREAM_%d] Camera frequency ('frame_rate') "
+            "cannot be read. Using 30 Hz.",
+            id);
         frame_rate = 30;
     }
 
@@ -130,7 +137,7 @@ int main(int argc, char** argv) {
 
     if (cim.isCalibrated())
         ROS_INFO("[NETCAM_STREAM_%d] Camera is calibrated.", id);
-    else 
+    else
         ROS_WARN("[NETCAM_STREAM_%d] Camera is NOT calibrated!", id);
 
     std::string cam_url = "http://" + user + ":" + pass + "@192.168.107." +
@@ -139,23 +146,26 @@ int main(int argc, char** argv) {
     bool isOpened = net_cam.open(cam_url);
     if (!isOpened) {
         ROS_FATAL(
-            "[NETCAM_STREAM_%d] Network camera stream is not opened! Have you checked the username and password. Trying to access '%s'", 
-            id, ("http://" + user + ":{the_password}@192.168.107." + CAMERA_ID +
-                 "/mjpg/video.mjpg").c_str());
+            "[NETCAM_STREAM_%d] Network camera stream is not opened! "
+            "Have you checked the username and password. Trying to access '%s'",
+            id,
+            ("http://" + user + ":{the_password}@192.168.107." + CAMERA_ID +
+             "/mjpg/video.mjpg").c_str());
         clean_up_gracefully(CAMERA_ID);
         return 0;
     }
 
     ros::Rate loop_rate(30);
-    ros::Timer timer = node.createTimer(ros::Duration(1.0/frame_rate), publish_image_callback);
+    ros::Timer timer =
+        node.createTimer(ros::Duration(1.0 / frame_rate), publish_image_callback);
+
     while (node.ok()) {
         ros::spinOnce();
 
-        if (pub.getNumSubscribers() == 0)
-        {
+        if (cam_pub.getNumSubscribers() == 0) {
             loop_rate.sleep();
             continue;
-        }   
+        }
 
         cv::Mat frame;
         net_cam >> frame;
@@ -168,7 +178,7 @@ int main(int argc, char** argv) {
             continue;
         }
 
-        if (to_publish){
+        if (to_publish) {
             sensor_msgs::ImagePtr image = cv_bridge::CvImage(std_msgs::Header(), "bgr8",
                                                              frame).toImageMsg();
 


### PR DESCRIPTION
The main contribution of the PR is the addition of a valid timestamp to the published image and camera info. Additionally, the formatting of the code was adjusted to the one used in RAD. The separate publishers for image and camera info are also replaced with a single ImageTransport::CameraPublisher in order to avoid synchronisation issues.
